### PR TITLE
Only allow `macos-runner:sonoma` image (#1278)

### DIFF
--- a/docs/guide/macOS.md
+++ b/docs/guide/macOS.md
@@ -5,7 +5,7 @@ Use `macos_instance` in your `.cirrus.yml` files:
 
 ```yaml
 macos_instance:
-  image: ghcr.io/cirruslabs/macos-sonoma-base:latest
+  image: ghcr.io/cirruslabs/macos-runner:sonoma
 
 task:
   script: echo "Hello World from macOS!"
@@ -14,11 +14,7 @@ task:
 ### Available images
 
 Cirrus CI is using [Tart virtualization](https://github.com/cirruslabs/tart) for running macOS Virtual Machines on Apple Silicon.
-Cirrus CI Cloud only allows [images managed and regularly updated by us](https://github.com/orgs/cirruslabs/packages?tab=packages&q=macos)
-where with Cirrus CLI you can [run any Tart VM](https://github.com/cirruslabs/tart/blob/main/README.md#ci-integration) on your infrastructure.
-
-Please refer to the [`macos-image-templates`](https://github.com/cirruslabs/macos-image-templates) repository on how the images were built and
-don't hesitate to [create issues](https://github.com/cirruslabs/macos-image-templates/issues) if current images are missing something.
+Cirrus CI Cloud only allows `ghcr.io/cirruslabs/macos-runner:sonoma` image which contains the last 3 versions of Xcode.
 
 !!! info "Underlying Orchestration Technology"
     Under the hood Cirrus CI is using Cirrus CI's own [Persistent Workers](persistent-workers.md). See more details in


### PR DESCRIPTION
To improve startup time and save on disk space.